### PR TITLE
Update SQL Task 2 - New car releases 2022 - relational databases fina…

### DIFF
--- a/SQL Task 2 - New car releases 2022 - relational databases final.sql
+++ b/SQL Task 2 - New car releases 2022 - relational databases final.sql
@@ -476,7 +476,7 @@ SELECT * FROM Telford_Motor_Show
 where type_of_test_drive = 'off-road experience';
 
 SELECT * FROM Telford_Motor_Show
-where type_of_test_drive = 'high speed passenger ride';
+where type_of_test_drive = '%high speed passenger ride%';
 
 SELECT * FROM Telford_Motor_Show
 where type_of_test_drive = 'road test,high speed passenger ride';
@@ -494,12 +494,12 @@ WHERE new_car_releases.model = Telford_Motor_Show.model AND Telford_Motor_Show.a
 SELECT *
 FROM new_car_releases
 INNER JOIN Telford_Motor_Show
-WHERE new_car_releases.model = Telford_Motor_Show.model AND new_car_releases.fuel_type = "hybrid";
+WHERE new_car_releases.model = Telford_Motor_Show.model AND new_car_releases.fuel_type = "%hybrid%";
 
 SELECT *
 FROM Telford_Motor_Show
 INNER JOIN new_car_releases
-WHERE Telford_Motor_Show.model = new_car_releases.model AND new_car_releases.fuel_type = "electric";
+WHERE Telford_Motor_Show.model = new_car_releases.model AND new_car_releases.fuel_type = "%electric%";
 
 SELECT *
 FROM new_car_releases


### PR DESCRIPTION
…l.sql

When running a query on a column with a 'SET' data type, only results with exactly what was queried were returned. For example, searching which cars were available for a high-speed passenger ride (HSPR) would return no cars. This is because they weren't just available for a HSPR. Initially, this was solved by searching for 'road test, high speed passenger ride' as all of the ones available for a HSPR were also available for a road test. There was a similar problem with lines 497 and 502 but these couldn't be solved by searching for all possible entries in the field as each entry with hybrid (497) or electric (502) had different alternative fuel types. To get around this, I used the wildcard symbol (%) before and after the keyword, enabling all entries that had the keyword as an option  to be shown.